### PR TITLE
Tf error output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ _testmain.go
 # testing files
 _combined*
 _remote*
+
+# binary
+colonize

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -24,13 +24,15 @@ func Run(c *config.ColonizeConfig, l log.Logger, skipRemote bool, remoteAfterApp
 	}
 
 	l.Log("Executing terraform apply")
-	util.RunCmd(
+        err,output := util.RunCmd(
 		"terraform",
 		"apply",
 		"-parallelism", "1",
 		"-var-file", c.CombinedValsFilePath,
 		"-var-file", c.CombinedDerivedValsFilePath,
 	)
+
+        l.Log(output)
 
 	if skipRemote {
 		if remoteAfterApply {
@@ -43,5 +45,5 @@ func Run(c *config.ColonizeConfig, l log.Logger, skipRemote bool, remoteAfterApp
 		}
 	}
 
-	return nil
+	return err
 }

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -23,7 +23,10 @@ to quickly create a Cobra application.`,
 			Log.Log(err.Error())
 			os.Exit(-1)
 		}
-		err = destroy.Run(conf, Log, SkipRemote)
+
+                err,output := destroy.Run(conf, Log, SkipRemote)
+                Log.Log(output)
+
 		if err != nil {
 			Log.Log("Destroy failed to run: " + err.Error())
 			os.Exit(-1)

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -24,7 +24,10 @@ to quickly create a Cobra application.`,
 			Log.Log(err.Error())
 			os.Exit(-1)
 		}
-		err = plan.Run(conf, Log, SkipRemote)
+
+                err,output := plan.Run(conf, Log, SkipRemote)
+                Log.Log(output)
+
 		if err != nil {
 			Log.Log("Plan failed to run: " + err.Error())
 			os.Exit(-1)

--- a/destroy/destroy.go
+++ b/destroy/destroy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/craigmonson/colonize/util"
 )
 
-func Run(c *config.ColonizeConfig, l log.Logger, skipRemote bool) error {
+func Run(c *config.ColonizeConfig, l log.Logger, skipRemote bool) (error,string) {
 	os.Chdir(c.TmplPath)
 
 	if skipRemote {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -14,7 +14,7 @@ import (
 	"github.com/craigmonson/colonize/util"
 )
 
-func Run(c *config.ColonizeConfig, l log.Logger, skipRemote bool) error {
+func Run(c *config.ColonizeConfig, l log.Logger, skipRemote bool) (error,string) {
 	os.Chdir(c.TmplPath)
 
 	// always run prep first

--- a/util/shellout.go
+++ b/util/shellout.go
@@ -5,7 +5,6 @@ import (
 )
 
 type Cmder interface {
-	Run() error
         CombinedOutput() ([]byte, error)
 }
 

--- a/util/shellout.go
+++ b/util/shellout.go
@@ -6,6 +6,7 @@ import (
 
 type Cmder interface {
 	Run() error
+        CombinedOutput() ([]byte, error)
 }
 
 type Cmd struct {
@@ -16,7 +17,9 @@ var NewCmd = func(cmd string, arg ...string) Cmder {
 	return exec.Command(cmd, arg...)
 }
 
-func RunCmd(cmd string, arg ...string) error {
+func RunCmd(cmd string, arg ...string) (error,string) {
 	newCmd := NewCmd(cmd, arg...)
-	return newCmd.Run()
+        output, err := newCmd.CombinedOutput()
+
+        return err,string(output)
 }

--- a/util/shellout_test.go
+++ b/util/shellout_test.go
@@ -1,7 +1,6 @@
 package util_test
 
 import (
-	//"fmt"
 	"os/exec"
 
 	. "github.com/craigmonson/colonize/util"
@@ -16,9 +15,9 @@ type mockCmd struct {
 	callCount int
 }
 
-func (c *mockCmd) Run() error {
+func (c *mockCmd) CombinedOutput() ([]byte, error) {
 	c.callCount++
-	return nil
+	return []byte("test"),nil
 }
 
 // NOTE: this is actually testing the 'test' directory in the root of the
@@ -49,6 +48,7 @@ var _ = Describe("util/shellout", func() {
 	Describe("RunCmd", func() {
 		var origFunc func(string, ...string) Cmder
 		var err error
+                var output string
 		var mocked *mockCmd
 
 		BeforeEach(func() {
@@ -59,7 +59,7 @@ var _ = Describe("util/shellout", func() {
 				return mocked
 			}
 
-			err = RunCmd("ls", "-l")
+			err,output = RunCmd("ls", "-l")
 
 		})
 		AfterEach(func() {
@@ -73,5 +73,9 @@ var _ = Describe("util/shellout", func() {
 		It("should have called Run", func() {
 			Ω(mocked.callCount).To(Equal(1))
 		})
+
+                It("should have an output", func() {
+                        Ω(output).ShouldNot(BeEmpty())
+                })
 	})
 })

--- a/util_mock/mock.go
+++ b/util_mock/mock.go
@@ -13,9 +13,9 @@ type MockCmd struct {
 	Cmd       string
 }
 
-func (c *MockCmd) Run() error {
+func (c *MockCmd) CombinedOutput() ([]byte, error) {
 	c.CallCount++
-	return nil
+	return []byte("test"),nil
 }
 
 var MCmd = &MockCmd{}


### PR DESCRIPTION

addresses issue #1 

Updates should print the TF output now. I had to modify the code a bit, but it should all be working and all tests pass. Having to use `CombinedOutput` instead of plain `Run`. I also had to push the output back up to where we can Log the output sanely.

