### PR TITLE
Allow yaml and yml

### DIFF
--- a/util/paths.go
+++ b/util/paths.go
@@ -7,18 +7,21 @@ import (
 	"strings"
 )
 
-const RootFile = ".colonize.yaml"
+var RootFiles = []string {".colonize.yaml", ".colonize.yml"}
 
 // search through myPath till you find the config file, and return the path to
 // it.
 func FindCfgPath(myPath string) (string, error) {
 	// cleanup and combine config file and search path
 	cleanedP := path.Clean(myPath)
-	fSearch := path.Join(cleanedP, RootFile)
 
-	// if the file exists, return the full path to the config file.
-	if fileExists(fSearch) {
-		return fSearch, nil
+	for _,rootfile := range RootFiles {
+		fSearch := path.Join(cleanedP, rootfile)
+
+		// if the file exists, return the full path to the config file.
+		if fileExists(fSearch) {
+			return fSearch, nil
+		}
 	}
 
 	// split it for recurisve search.
@@ -26,7 +29,7 @@ func FindCfgPath(myPath string) (string, error) {
 
 	// if this is the end of the line for the path, return an error
 	if newP == "/" || newP == "" || newP == "." || newP == ".." {
-		return "", errors.New(RootFile + " not found in the directory tree.")
+		return "", errors.New(RootFiles[0] + " not found in the directory tree.")
 	}
 
 	// recurse

--- a/util/paths_test.go
+++ b/util/paths_test.go
@@ -14,7 +14,7 @@ var _ = Describe("util/paths", func() {
 	path := "../test/"
 
 	Describe("FindCfgPath", func() {
-		Context("given a path that contains a "+RootFile, func() {
+		Context("given a path that contains a "+RootFiles[0], func() {
 			var testPath string
 
 			BeforeEach(func() {
@@ -22,7 +22,7 @@ var _ = Describe("util/paths", func() {
 			})
 
 			It("should return the full path to the config file", func() {
-				Ω(testPath).To(Equal(path + RootFile))
+				Ω(testPath).To(Equal(path + RootFiles[0]))
 			})
 
 			It("should not return an error", func() {
@@ -30,7 +30,7 @@ var _ = Describe("util/paths", func() {
 			})
 		})
 
-		Context("given a path that doesn't have a "+RootFile, func() {
+		Context("given a path that doesn't have a "+RootFiles[0], func() {
 			var testPath string
 
 			BeforeEach(func() {
@@ -42,7 +42,7 @@ var _ = Describe("util/paths", func() {
 			})
 
 			It("should return an error", func() {
-				Ω(err).Should(MatchError(RootFile + " not found in the directory tree."))
+				Ω(err).Should(MatchError(RootFiles[0] + " not found in the directory tree."))
 			})
 		})
 	})


### PR DESCRIPTION

Fixes #9 

Will currently allow `.colonize.yaml` and `.colonize.yml`, but could be extended further if needed by adding to the RootFiles array