### PR TITLE
updated commands to require/not-require environment

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -18,7 +18,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig()
+		conf, err := GetConfig(false)
 		if err != nil {
 			Log.Log(err.Error())
 			os.Exit(-1)

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -18,7 +18,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig()
+		conf, err := GetConfig(false)
 		if err != nil {
 			Log.Log(err.Error())
 			os.Exit(-1)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -18,7 +18,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig()
+		conf, err := GetConfig(true)
 		if err != nil {
 			Log.Log(err.Error())
 			os.Exit(-1)

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -19,7 +19,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig()
+		conf, err := GetConfig(true)
 		if err != nil {
 			Log.Log(err.Error())
 			os.Exit(-1)

--- a/cmd/prep.go
+++ b/cmd/prep.go
@@ -18,7 +18,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig()
+		conf, err := GetConfig(true)
 		if err != nil {
 			Log.Log(err.Error())
 			os.Exit(-1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,13 +33,13 @@ to quickly create a Cobra application.`,
 }
 
 // This is available for all the subcommands
-func GetConfig() (*config.ColonizeConfig, error) {
+func GetConfig(requireEnvironment bool) (*config.ColonizeConfig, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 
-	if Environment == "" {
+	if requireEnvironment && Environment == "" {
 		return nil, errors.New("environment can not be empty")
 	}
 
@@ -50,6 +50,7 @@ func GetConfig() (*config.ColonizeConfig, error) {
 
 	return config, err
 }
+
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.


### PR DESCRIPTION

fixes #3

currently have it setup to:

require environment
- prep
- plan
- destroy

does not require environment
- clean
- apply (i do not think it is needed here, because the tfplan should have environment encapsulated)