### PR TITLE
remove .terraform dir

### DIFF
--- a/clean/clean.go
+++ b/clean/clean.go
@@ -32,8 +32,8 @@ func Run(c *config.ColonizeConfig, l log.Logger) error {
 	}
 
 	for _, file := range filesToClean {
-		l.Log("rm -f " + file)
-		util.RunCmd("rm", "-f", file)
+		l.Log("rm -rf " + file)
+		util.RunCmd("rm", "-rf", file)
 	}
 
 	return nil


### PR DESCRIPTION

The .terraform was not being removed because it did not have the `-r` flag. I just added the flag as it will not hurt for removing the single files. 

Also, it would be more efficient to just do:

```
util.RunCmd("rm", "-rf", strings.Join(filesToClean, " "))
```

instead of the loop. thoughts?