### PR TITLE
added require env

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -21,7 +21,7 @@ Example usage to apply changes:
 $ colonize apply
         `,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig(false)
+		conf, err := GetConfig(true)
 		if err != nil {
 			Log.Log(err.Error())
 			os.Exit(-1)


### PR DESCRIPTION

If you run `plan` then the `environment` would not technically be necessary, however, you are allowed in TF to directly run `apply` which will do an implicit `plan`. Because of this, I think we must require the environment flag as a guard rail