### PR TITLE
added environments command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"os"
+  "os"
 
-	"github.com/craigmonson/colonize/config"
-	"github.com/craigmonson/colonize/initialize"
-	"github.com/spf13/cobra"
+  "github.com/craigmonson/colonize/config"
+  "github.com/craigmonson/colonize/initialize"
+  "github.com/spf13/cobra"
 )
 
 const Header string = `
@@ -26,59 +26,55 @@ manage your terraform templates. It revolves around the idea of
 environments, and allows you to organize templates, and template 
 data around that common idiom.
 
-Starting interactive setup:
 `
 
 const Footer string = "\n\nColoinze project initialization complete!"
 
 var acceptDefaults bool
+var initEnvironments string
 
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize a Colonize project",
-	Long:  `This command is used to aid in the generation the .colonize.yaml configuration file and project directory structure.`,
-	Run: func(cmd *cobra.Command, args []string) {
+  Use:   "init",
+  Short: "Initialize a Colonize project",
+  Long:  `This command is used to aid in the generation the .colonize.yaml configuration file and project directory structure.`,
+  Run: func(cmd *cobra.Command, args []string) {
 
-		Log.Log(Header)
+    Log.Log(Header)
 
-		_, err := GetConfig(false)
-		if err == nil {
-			Log.Log("Colonize project already initialized. Exiting.")
-			os.Exit(0)
-		}
+    _, err := GetConfig(false)
+    if err == nil {
+      Log.Log("Colonize project already initialized. Exiting.")
+      os.Exit(0)
+    }
 
-		var blankConfig config.Config
-		err = initialize.Run(&blankConfig, Log, acceptDefaults)
-		if err != nil {
-			Log.Log("ERROR: " + err.Error())
-			os.Exit(-1)
-		}
+    var blankConfig config.Config
+    err = initialize.Run(&blankConfig, Log, initialize.RunArgs{
+      AcceptDefaults: acceptDefaults,
+      InitEnvironments: initEnvironments,
+    })
+    if err != nil {
+      Log.Log("ERROR: " + err.Error())
+      os.Exit(-1)
+    }
 
-		err = blankConfig.ConfigFile.WriteToFile(".colonize.yaml")
-		if err != nil {
-			Log.Log("ERROR: Failed to create configuration file: " + err.Error())
-			os.Exit(-1)
-		}
-		Log.Log("\nConfiguration file saved...")
-
-		err = os.Mkdir(blankConfig.ConfigFile.Environments_Dir, 0755)
-		if err != nil {
-			Log.Log("ERROR: Failed to crete environments directory: " + err.Error())
-			os.Exit(-1)
-		}
-		Log.Log("Environments directory created...")
-
-		Log.Log(Footer)
-	},
+    Log.Log(Footer)
+  },
 }
 
 func init() {
-	initCmd.Flags().BoolVarP(
-		&acceptDefaults,
-		"accept-defaults",
-		"",
-		false,
-		"automatically accepts default values, skipping manual setup",
-	)
-	RootCmd.AddCommand(initCmd)
+  initCmd.Flags().BoolVarP(
+    &acceptDefaults,
+    "accept-defaults",
+    "",
+    false,
+    "automatically accepts default values, skipping manual setup",
+  )
+  initCmd.Flags().StringVarP(
+    &initEnvironments,
+    "environments",
+    "",
+    "",
+    "specify environment files to initialize the project with",
+  )
+  RootCmd.AddCommand(initCmd)
 }

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -11,16 +11,26 @@ import (
 
   "github.com/craigmonson/colonize/config"
   "github.com/craigmonson/colonize/log"
+  "github.com/craigmonson/colonize/util"
 )
 
-func Run(c *config.Config, l log.Logger, acceptDefaults bool) error {
+type RunArgs struct {
+  AcceptDefaults bool
+  InitEnvironments string
+}
 
+func Run(c *config.Config, l log.Logger, args interface{}) error {
   var configBuffer bytes.Buffer
+  runArgs := args.(RunArgs)
 
   scan := bufio.NewScanner(os.Stdin)
   defaults := reflect.ValueOf(&config.ConfigFileDefaults).Elem()
   actuals := reflect.ValueOf(&c.ConfigFile).Elem()
   typeof := defaults.Type()
+
+  if !runArgs.AcceptDefaults {
+    l.Log("Starting interactive setup:")
+  }
 
   // Iterate through each field in the config file struct
   // asking for user inout or setting to a default
@@ -30,7 +40,7 @@ func Run(c *config.Config, l log.Logger, acceptDefaults bool) error {
     defaultField := defaults.Field(i)
     actualField := actuals.Field(i)
 
-    if acceptDefaults || strings.HasPrefix(fieldName,"autogenerate_"){
+    if runArgs.AcceptDefaults || strings.HasPrefix(fieldName,"autogenerate_"){
       actualField.Set(reflect.Value(defaultField))
     } else {
       l.Print(fmt.Sprintf("Enter '%s' [%v]: ", fieldName, defaultField.Interface()))
@@ -47,10 +57,10 @@ func Run(c *config.Config, l log.Logger, acceptDefaults bool) error {
     configBuffer.WriteString(fmt.Sprintf("%-30s => %v\n",fieldName,actualField.Interface()))
   }
 
-  if !acceptDefaults {
-    // print configuration details
-    l.Log(fmt.Sprintf("\n\nInitializing Colonize using the following config:\n%s\n",configBuffer.String()))
+  // print configuration details
+  l.Log(fmt.Sprintf("\nInitializing Colonize using the following config:\n%s\n",configBuffer.String()))
 
+  if !runArgs.AcceptDefaults {
     // Confirm initialization
     accept := ""
     for accept == "" {
@@ -62,6 +72,38 @@ func Run(c *config.Config, l log.Logger, acceptDefaults bool) error {
     if accept != "y" {
       return errors.New("Colonize initialization cancelled by user")
     }
+
+    if runArgs.InitEnvironments == "" {
+      l.Print("\nProvide a comma-separated list of environment names to initialize []: ")
+      scan.Scan()
+      runArgs.InitEnvironments = scan.Text()
+    }
+
+  }
+
+  err := c.ConfigFile.WriteToFile(".colonize.yaml")
+  if err != nil {
+    return errors.New("Failed to create .colonize.yaml file: " + err.Error())
+  } else {
+    l.Log("Created Configuration file")
+  }
+
+  err = os.Mkdir(c.ConfigFile.Environments_Dir, 0755)
+  if err != nil {
+    os.Remove(".colonize.yaml")
+    return errors.New("Failed to create environments directory: " + err.Error())
+  } else {
+    l.Log("Created Environments directory")
+  }
+
+  util.Touch(c.ConfigFile.Branch_Order_File)
+  l.Log("Created Branch Order File")
+
+  envs := strings.Split(runArgs.InitEnvironments,",")
+  for _,env := range envs {
+    fn := env + ".tfvars"
+    util.Touch(c.ConfigFile.Environments_Dir, fn)
+    l.Log(fmt.Sprintf("Created %s environment variable file", env))
   }
 
   return nil

--- a/initialize/init_test.go
+++ b/initialize/init_test.go
@@ -1,41 +1,94 @@
 package initialize_test
 
 import (
-  "reflect"
-
-  "github.com/craigmonson/colonize/config"
-  "github.com/craigmonson/colonize/log_mock"
   . "github.com/craigmonson/colonize/initialize"
 
   . "github.com/onsi/ginkgo"
   . "github.com/onsi/gomega"
+
+  "io/ioutil"
+  "os"
+  "reflect"
+
+  "github.com/craigmonson/colonize/config"
+  "github.com/craigmonson/colonize/log_mock"
 )
 
-var _ = Describe("Init", func() {
+var test_dir string
+var cwd string
+var err error
+var cfg config.Config
 
-  Describe("Run", func() {
-    var conf config.Config
-    var mLog *log_mock.MockLog
-    var err error
+var _ = BeforeSuite(func() {
 
-    BeforeEach(func() {
-      mLog = &log_mock.MockLog{}
-      err = Run(&conf, mLog, true)
-    })
+  cwd,err = os.Getwd()
+  if err != nil {
+    panic(err.Error())
+  }
 
-    It("should not raise an error", func() {
-      Ω(err).ToNot(HaveOccurred())
-    })
+  test_dir, err = ioutil.TempDir("","branch_test")
+  if err != nil {
+    panic(err.Error())
+  }
 
-    It("should setup config data w/ defaults", func() {
+  err = os.Chdir(test_dir)
+  if err != nil {
+    panic(err.Error())
+  }
 
-      defaults := reflect.ValueOf(&config.ConfigFileDefaults).Elem()
-      actuals := reflect.ValueOf(&conf.ConfigFile).Elem()
+  cfg = config.Config{
+    RootPath: test_dir,
+    TmplPath: test_dir,
+    ConfigFile: config.ConfigFile{},
+  }
 
-      for i := 0; i< defaults.NumField(); i++ {
-        Ω(actuals.Field(i).String()).To(Equal(defaults.Field(i).String()))
-      }
-
-    })
+  Run(&cfg, &log_mock.MockLog{}, RunArgs{
+    AcceptDefaults: true,
+    InitEnvironments: "dev,prod",
   })
+})
+
+var _ = AfterSuite(func() {
+  os.Chdir(cwd)
+  os.RemoveAll(test_dir)
+})
+
+var _ = Describe("init", func() {
+
+  It("should not raise an error", func() {
+    Ω(err).ToNot(HaveOccurred())
+  })
+
+  It("should setup config data w/ defaults", func() {
+    defaults := reflect.ValueOf(&config.ConfigFileDefaults).Elem()
+    actuals := reflect.ValueOf(&cfg.ConfigFile).Elem()
+
+    for i := 0; i< defaults.NumField(); i++ {
+      Ω(actuals.Field(i).String()).To(Equal(defaults.Field(i).String()))
+    }
+
+  })
+
+  It("should have created a .colonize.yaml", func() {
+    _, err := os.Stat(".colonize.yaml")
+    Ω(err).ShouldNot(HaveOccurred())
+  })
+
+  It("should have created a branch order file", func() {
+    _, err := os.Stat("build_order.txt")
+    Ω(err).ShouldNot(HaveOccurred())
+  })
+
+  It("should have created a directory for the env", func() {
+    _, err := os.Stat("env")
+    Ω(err).ShouldNot(HaveOccurred())
+  })
+
+  It("should have created environment tfvars inside the env directory", func() {
+    _, err := os.Stat("env/dev.tfvars")
+    Ω(err).ShouldNot(HaveOccurred())
+    _, err = os.Stat("env/prod.tfvars")
+    Ω(err).ShouldNot(HaveOccurred())
+  })
+
 })

--- a/util/paths.go
+++ b/util/paths.go
@@ -94,8 +94,8 @@ func fileExists(p string) bool {
 	return false
 }
 
-func Touch(p string, n string) error {
-  fn, err := os.Create(path.Join(p,n))
+func Touch(p ...string) error {
+  fn, err := os.Create(path.Join(p...))
   defer fn.Close()
   return err
 }


### PR DESCRIPTION

fixes #41 

This will allow you to generate environments via init. Say you know you are going to have dev, test, & prod environments when you start your new application. You can now specify a list to create them like so:

`colonize init --accept-defaults --environments dev,test,prod`

This will result in the tfvars files getting created in the `env` folder. This can come in handy when wanting to automate a standard base environment, like so:

```
colonize init --accept-defaults --environments dev,test,prod
colonize generate leaf vpc
colonize generate leaf iam
colonize generate branch myapp --leafs security_groups,iam,database,instances
```

giving the following project structure:
```
.
├── .colonize.yaml
├── build_order.txt
├── env
│   ├── dev.tfvars
│   ├── prod.tfvars
│   └── test.tfvars
├── iam
│   └── main.tf
├── myapp
│   ├── build_order.txt
│   ├── database
│   │   └── main.tf
│   ├── env
│   │   ├── dev.tfvars
│   │   ├── prod.tfvars
│   │   └── test.tfvars
│   ├── iam
│   │   └── main.tf
│   ├── instances
│   │   └── main.tf
│   └── security_groups
│       └── main.tf
└── vpc
    └── main.tf
```