### PR TITLE
Better output

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -25,22 +25,17 @@ func Run(c *config.Config, l log.Logger, args interface{}) error {
 		l.Log("Skipping remote setup")
 	} else {
 		l.Log("Running remote setup")
-		// why is this being run twice?  accident?
-		//util.RunCmd(c.CombinedRemoteFilePath)
-		_, output := util.RunCmd(c.CombinedRemoteFilePath)
-		l.Log(output)
+		util.RunCmd(c.CombinedRemoteFilePath)
 	}
 
 	l.Log("Executing terraform apply")
-	err, output := util.RunCmd(
+	err := util.RunCmd(
 		"terraform",
 		"apply",
 		"-parallelism", "1",
 		"-var-file", c.CombinedValsFilePath,
 		"-var-file", c.CombinedDerivedValsFilePath,
 	)
-
-	l.Log(output)
 
 	if runArgs.SkipRemote {
 		if runArgs.RemoteStateAfterApply {
@@ -59,6 +54,5 @@ func remoteUpdate(c *config.Config, l log.Logger) {
 	l.Log("Running remote after apply")
 	os.Rename("terraform.tfstate", ".terraform/terraform.tfstate")
 	util.RunCmd("rm terraform.tfstate.backup")
-	_, output := util.RunCmd(c.CombinedRemoteFilePath)
-	l.Log(output)
+	util.RunCmd(c.CombinedRemoteFilePath)
 }

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -1,13 +1,8 @@
 package apply
 
 import (
-	//	"bytes"
-	//	//"fmt"
-	//	"io/ioutil"
 	"os"
-	//	"regexp"
-	//	"strings"
-	//
+
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
 	"github.com/craigmonson/colonize/util"

--- a/clean/clean.go
+++ b/clean/clean.go
@@ -1,13 +1,14 @@
 package clean
 
 import (
+	"fmt"
+
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
 	"github.com/craigmonson/colonize/util"
 )
 
 func Run(c *config.Config, l log.Logger, args interface{}) error {
-	l.Log("Cleaning up")
 	filesToClean := []string{
 		c.CombinedValsFilePath,
 		c.CombinedVarsFilePath,
@@ -23,7 +24,7 @@ func Run(c *config.Config, l log.Logger, args interface{}) error {
 	}
 
 	for _, file := range filesToClean {
-		l.Log("rm -rf " + file)
+		l.Log(fmt.Sprintf("Deleting %s...",util.GetBasename(file)))
 		util.RunCmd("rm", "-rf", file)
 	}
 

--- a/clean/clean_test.go
+++ b/clean/clean_test.go
@@ -39,8 +39,7 @@ var _ = Describe("Clean", func() {
 			})
 
 			It("should log some stuff", func() {
-				Ω(mLog.Output).To(MatchRegexp("Cleaning up"))
-				Ω(mLog.Output).To(MatchRegexp("rm -rf "))
+				Ω(mLog.Output).To(MatchRegexp("Deleting "))
 			})
 		})
 	})

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -33,7 +33,7 @@ $ colonize apply --environment dev --skip-remote --remote-state-after-apply
 			Log.Log(err.Error())
 			os.Exit(-1)
 		}
-		err = Run(apply.Run, conf, Log, false, apply.RunArgs{
+		err = Run("APPLY", apply.Run, conf, Log, false, apply.RunArgs{
 			SkipRemote:            SkipRemote,
 			RemoteStateAfterApply: RemoteStateAfterApply,
 		})

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/craigmonson/colonize/apply"
@@ -30,17 +28,18 @@ $ colonize apply --environment dev --skip-remote --remote-state-after-apply
 	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := GetConfig(true)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
+
 		err = Run("APPLY", apply.Run, conf, Log, false, apply.RunArgs{
 			SkipRemote:            SkipRemote,
 			RemoteStateAfterApply: RemoteStateAfterApply,
 		})
 		if err != nil {
-			Log.Log("Apply failed to run: " + err.Error())
-			os.Exit(-1)
+			CompleteFail("Apply failed to run: " + err.Error())
 		}
+
+		CompleteSucceed()
 	},
 }
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -26,7 +26,7 @@ $ colonize clean
 			Log.Log(err.Error())
 			os.Exit(-1)
 		}
-		err = Run(clean.Run, conf, Log, false, nil)
+		err = Run("CLEAN", clean.Run, conf, Log, false, nil)
 		if err != nil {
 			Log.Log("Clean failed to run: " + err.Error())
 			os.Exit(-1)

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/craigmonson/colonize/clean"
@@ -23,14 +21,14 @@ $ colonize clean
 	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := GetConfig(false)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail("Clean failed to run: " + err.Error())
 		}
 		err = Run("CLEAN", clean.Run, conf, Log, false, nil)
 		if err != nil {
-			Log.Log("Clean failed to run: " + err.Error())
-			os.Exit(-1)
+			CompleteFail("Clean failed to run: " + err.Error())
 		}
+
+		CompleteSucceed()
 	},
 }
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/craigmonson/colonize/destroy"
+	"github.com/craigmonson/colonize/prep"
 )
 
 var yesToDestroy bool
@@ -33,8 +34,7 @@ $ colonize destroy -e dev -y
 	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := GetConfig(true)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
 		if !yesToDestroy {
@@ -43,9 +43,13 @@ $ colonize destroy -e dev -y
 			scan.Scan()
 
 			if scan.Text() != "yes" {
-				Log.Log("Destroy operation cancelled by user")
-				os.Exit(0)
+				CompleteFail("Destroy operation cancelled by user")
 			}
+		}
+
+		err = Run("PREP", prep.Run, conf, Log, false, nil)
+		if err != nil {
+			CompleteFail("Prep failed to run: " + err.Error())
 		}
 
 		err = Run("DESTROY", destroy.Run, conf, Log, true, destroy.RunArgs{
@@ -53,9 +57,10 @@ $ colonize destroy -e dev -y
 		})
 
 		if err != nil {
-			Log.Log("Destroy failed to run: " + err.Error())
-			os.Exit(-1)
+			CompleteFail("Destroy failed to run: " + err.Error())
 		}
+
+		CompleteSucceed()
 	},
 }
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -48,7 +48,7 @@ $ colonize destroy -e dev -y
 			}
 		}
 
-		err = Run(destroy.Run, conf, Log, true, destroy.RunArgs{
+		err = Run("DESTROY", destroy.Run, conf, Log, true, destroy.RunArgs{
 			SkipRemote: SkipRemote,
 		})
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -49,8 +49,7 @@ colonize generate branch mybranch --leafs myleaf1,myleaf2
 
 		err := generate.ValidateArgsLength("Branch", args, 1, 1)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
 		name := args[0]
@@ -58,14 +57,12 @@ colonize generate branch mybranch --leafs myleaf1,myleaf2
 
 		err = generate.ValidateNameAvailable("Branch", name)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
 		conf, err := GetConfig(false)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
 		err = branch.Run(conf, Log, branch.RunArgs{
@@ -73,9 +70,10 @@ colonize generate branch mybranch --leafs myleaf1,myleaf2
 			Leafs: leafs,
 		})
 		if err != nil {
-			Log.Log("Generate Branch failed to run: " + err.Error())
-			os.Exit(-1)
+			CompleteFail("Generate Branch failed to run: " + err.Error())
 		}
+
+		CompleteSucceed()
 
 	},
 }
@@ -95,27 +93,23 @@ colonize generate leaf myleaf
 
 		err := generate.ValidateArgsLength("Leaf", args, 1, 1)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
 		name := args[0]
 		err = generate.ValidateNameAvailable("Leaf", name)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
 		conf, err := GetConfig(false)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
 		build_order, err := os.OpenFile(conf.ConfigFile.Branch_Order_File, os.O_APPEND|os.O_WRONLY, 0664)
 		if err != nil {
-			Log.Log(fmt.Sprintf("Failed to add leaf '%s' to '%s'", name, "build_order.txt"))
-			os.Exit(-1)
+			CompleteFail(fmt.Sprintf("Failed to add leaf '%s' to '%s'", name, "build_order.txt"))
 		}
 		defer build_order.Close()
 
@@ -124,9 +118,10 @@ colonize generate leaf myleaf
 			BuildOrder: build_order,
 		})
 		if err != nil {
-			Log.Log("Generate Leaf failed to run: " + err.Error())
-			os.Exit(-1)
+			CompleteFail("Generate Leaf failed to run: " + err.Error())
 		}
+
+		CompleteSucceed()
 
 	},
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,34 +1,10 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/initialize"
 	"github.com/spf13/cobra"
 )
-
-const Header string = `
-  ______             __                      __                     
- /      \           |  \                    |  \                    
-|  $$$$$$\  ______  | $$  ______   _______   \$$ ________   ______  
-| $$   \$$ /      \ | $$ /      \ |       \ |  \|        \ /      \ 
-| $$      |  $$$$$$\| $$|  $$$$$$\| $$$$$$$\| $$ \$$$$$$$$|  $$$$$$\
-| $$   __ | $$  | $$| $$| $$  | $$| $$  | $$| $$  /    $$ | $$    $$
-| $$__/  \| $$__/ $$| $$| $$__/ $$| $$  | $$| $$ /  $$$$_ | $$$$$$$$
- \$$    $$ \$$    $$| $$ \$$    $$| $$  | $$| $$|  $$    \ \$$     \
-  \$$$$$$   \$$$$$$  \$$  \$$$$$$  \$$   \$$ \$$ \$$$$$$$$  \$$$$$$$
-                                                                    
---------------------------------------------------------------------
-
-Colonize is a configurable, albeit opinionated way to organize and 
-manage your terraform templates. It revolves around the idea of 
-environments, and allows you to organize templates, and template 
-data around that common organizational structure.
-
-`
-
-const Footer string = "\n\nColoinze project initialization complete!"
 
 var acceptDefaults bool
 var initEnvironments string
@@ -39,12 +15,9 @@ var initCmd = &cobra.Command{
 	Long:  `This command is used to aid in the generation the .colonize.yaml configuration file and project directory structure.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		Log.Log(Header)
-
 		_, err := GetConfig(false)
 		if err == nil {
-			Log.Log("Colonize project already initialized. Exiting.")
-			os.Exit(0)
+			CompleteFail("Colonize project already initialized. Exiting.")
 		}
 
 		var blankConfig config.Config
@@ -53,11 +26,10 @@ var initCmd = &cobra.Command{
 			InitEnvironments: initEnvironments,
 		})
 		if err != nil {
-			Log.Log("ERROR: " + err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 
-		Log.Log(Footer)
+		CompleteSucceed()
 	},
 }
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -33,7 +33,7 @@ $ colonize plan -e dev --skip-remote --remote-state-after-apply
 			os.Exit(-1)
 		}
 
-		err = Run(plan.Run, conf, Log, false, plan.RunArgs{
+		err = Run("PLAN", plan.Run, conf, Log, false, plan.RunArgs{
 			SkipRemote: SkipRemote,
 		})
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/craigmonson/colonize/plan"
+	"github.com/craigmonson/colonize/prep"
 )
 
 // planCmd represents the plan command
@@ -29,8 +28,12 @@ $ colonize plan -e dev --skip-remote --remote-state-after-apply
 	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := GetConfig(true)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
+		}
+
+		err = Run("PREP", prep.Run, conf, Log, false, nil)
+		if err != nil {
+			CompleteFail("Prep failed to run: " + err.Error())
 		}
 
 		err = Run("PLAN", plan.Run, conf, Log, false, plan.RunArgs{
@@ -38,9 +41,10 @@ $ colonize plan -e dev --skip-remote --remote-state-after-apply
 		})
 
 		if err != nil {
-			Log.Log("Plan failed to run: " + err.Error())
-			os.Exit(-1)
+			CompleteFail("Plan failed to run: " + err.Error())
 		}
+
+		CompleteSucceed()
 	},
 }
 

--- a/cmd/prep.go
+++ b/cmd/prep.go
@@ -34,7 +34,7 @@ $ colonize prep -e dev
 			Log.Log(err.Error())
 			os.Exit(-1)
 		}
-		err = Run(prep.Run, conf, Log, false, nil)
+		err = Run("PREP", prep.Run, conf, Log, false, nil)
 		if err != nil {
 			Log.Log("Prep Failed to Run: " + err.Error())
 			os.Exit(-1)

--- a/cmd/prep.go
+++ b/cmd/prep.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"os"
 
 	"github.com/craigmonson/colonize/prep"
 )
@@ -31,14 +30,14 @@ $ colonize prep -e dev
 	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := GetConfig(true)
 		if err != nil {
-			Log.Log(err.Error())
-			os.Exit(-1)
+			CompleteFail(err.Error())
 		}
 		err = Run("PREP", prep.Run, conf, Log, false, nil)
 		if err != nil {
-			Log.Log("Prep Failed to Run: " + err.Error())
-			os.Exit(-1)
+			CompleteFail("Prep Failed to Run: " + err.Error())
 		}
+
+		CompleteSucceed()
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
+	"github.com/craigmonson/colonize/util"
 )
 
 var Environment string
@@ -38,8 +39,13 @@ func GetConfig(requireEnvironment bool) (*config.Config, error) {
 		return nil, err
 	}
 
-	if requireEnvironment && Environment == "" {
-		return nil, errors.New("environment can not be empty")
+	if requireEnvironment {
+		if Environment == "" {
+			return nil, errors.New("environment can not be empty")
+		}
+		Log.Log(util.PadRight(fmt.Sprintf("\nColonize [%s] ", Environment), "*", 79))
+	} else {
+		Log.Log(util.PadRight("\nColonize ", "*", 79))
 	}
 
 	config, err := config.LoadConfigInTree(cwd, Environment)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/craigmonson/colonize/config"
@@ -43,9 +44,9 @@ func GetConfig(requireEnvironment bool) (*config.Config, error) {
 		if Environment == "" {
 			return nil, errors.New("environment can not be empty")
 		}
-		Log.Log(util.PadRight(fmt.Sprintf("\nCOLONIZE [%s] ", Environment), "*", 79))
+		Log.LogPretty(util.PadRight(fmt.Sprintf("\nCOLONIZE [%s] ", Environment), "*", 79), color.Bold)
 	} else {
-		Log.Log(util.PadRight("\nCOLONIZE ", "*", 79))
+		Log.LogPretty(util.PadRight("\nCOLONIZE ", "*", 79), color.Bold)
 	}
 
 	config, err := config.LoadConfigInTree(cwd, Environment)
@@ -66,14 +67,14 @@ func Execute() {
 }
 
 func CompleteSucceed() {
-	Log.Log(util.PadRight("\nRECAP ", "*", 79))
-	Log.Log("Completed successfully!")
+	Log.LogPretty(util.PadRight("\nRECAP ", "*", 79), color.Bold)
+	Log.LogPretty("Completed successfully!", color.FgGreen)
 	os.Exit(0)
 }
 
 func CompleteFail(err string) {
-	Log.Log(util.PadRight("\nRECAP ", "*", 79))
-	Log.Log(err)
+	Log.LogPretty(util.PadRight("\nRECAP ", "*", 79), color.Bold)
+	Log.LogPretty(err, color.FgRed)
 	os.Exit(-1)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,9 +43,9 @@ func GetConfig(requireEnvironment bool) (*config.Config, error) {
 		if Environment == "" {
 			return nil, errors.New("environment can not be empty")
 		}
-		Log.Log(util.PadRight(fmt.Sprintf("\nColonize [%s] ", Environment), "*", 79))
+		Log.Log(util.PadRight(fmt.Sprintf("\nCOLONIZE [%s] ", Environment), "*", 79))
 	} else {
-		Log.Log(util.PadRight("\nColonize ", "*", 79))
+		Log.Log(util.PadRight("\nCOLONIZE ", "*", 79))
 	}
 
 	config, err := config.LoadConfigInTree(cwd, Environment)
@@ -63,6 +63,18 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+}
+
+func CompleteSucceed() {
+	Log.Log(util.PadRight("\nRECAP ", "*", 79))
+	Log.Log("Completed successfully!")
+	os.Exit(0)
+}
+
+func CompleteFail(err string) {
+	Log.Log(util.PadRight("\nRECAP ", "*", 79))
+	Log.Log(err)
+	os.Exit(-1)
 }
 
 func init() {

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
+
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
 	"github.com/craigmonson/colonize/util"
@@ -16,7 +18,7 @@ func Run(name string, f func(*config.Config, log.Logger, interface{}) error, c *
 		return RunBranch(name, f, c, l, reverse, args)
 	}
 
-	l.Log(util.PadRight(fmt.Sprintf("\n%s [%s] ", name, c.TmplPath), "*", 79))
+	l.LogPretty(util.PadRight(fmt.Sprintf("\n%s [%s] ", name, c.TmplPath), "*", 79), color.Bold)
 	return f(c, l, args)
 }
 

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -1,24 +1,27 @@
 package cmd
 
 import (
+        "fmt"
 	"os"
 
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
+        "github.com/craigmonson/colonize/util"
+
 )
 
 // reverse is here because the destroy command will need to destroy stuff in
 // reverse order.
-func Run(f func(*config.Config, log.Logger, interface{}) error, c *config.Config, l log.Logger, reverse bool, args interface{}) error {
+func Run(name string, f func(*config.Config, log.Logger, interface{}) error, c *config.Config, l log.Logger, reverse bool, args interface{}) error {
 	if c.IsBranch() {
-		return RunBranch(f, c, l, reverse, args)
+		return RunBranch(name, f, c, l, reverse, args)
 	}
 
-	l.Log("Running " + c.TmplPath)
+        l.Log(util.PadRight(fmt.Sprintf("\n%s [%s] ", name, c.TmplPath),"*",79))
 	return f(c, l, args)
 }
 
-func RunBranch(f func(*config.Config, log.Logger, interface{}) error, c *config.Config, l log.Logger, reverse bool, args interface{}) error {
+func RunBranch(name string, f func(*config.Config, log.Logger, interface{}) error, c *config.Config, l log.Logger, reverse bool, args interface{}) error {
 	buildPaths, err := c.GetBuildOrderPaths()
 	if err != nil {
 		return err
@@ -39,7 +42,7 @@ func RunBranch(f func(*config.Config, log.Logger, interface{}) error, c *config.
 			return err
 		}
 
-		if err := Run(f, newConf, l, reverse, args); err != nil {
+		if err := Run(name, f, newConf, l, reverse, args); err != nil {
 			return err
 		}
 	}

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-        "fmt"
+	"fmt"
 	"os"
 
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
-        "github.com/craigmonson/colonize/util"
-
+	"github.com/craigmonson/colonize/util"
 )
 
 // reverse is here because the destroy command will need to destroy stuff in
@@ -17,7 +16,7 @@ func Run(name string, f func(*config.Config, log.Logger, interface{}) error, c *
 		return RunBranch(name, f, c, l, reverse, args)
 	}
 
-        l.Log(util.PadRight(fmt.Sprintf("\n%s [%s] ", name, c.TmplPath),"*",79))
+	l.Log(util.PadRight(fmt.Sprintf("\n%s [%s] ", name, c.TmplPath), "*", 79))
 	return f(c, l, args)
 }
 

--- a/cmd/runner_test.go
+++ b/cmd/runner_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Runner", func() {
 		Context("in normal order", func() {
 			It("should make the correct calls", func() {
 				c, err := config.LoadConfigInTree(cwd+"/../test", "dev")
-				err = Run(myRun, c, Log, false, nil)
+				err = Run("TEST", myRun, c, Log, false, nil)
 				Ω(r.callCount).To(Equal(3))
 				Ω(err).ToNot(HaveOccurred())
 				Ω(r.origin).To(MatchRegexp("../test/microservices"))
@@ -48,7 +48,7 @@ var _ = Describe("Runner", func() {
 		Context("in reverse order", func() {
 			It("should make the correct calls", func() {
 				c, err := config.LoadConfigInTree(cwd+"/../test", "dev")
-				err = Run(myRun, c, Log, true, nil)
+                                err = Run("TEST", myRun, c, Log, true, nil)
 				Ω(r.callCount).To(Equal(3))
 				Ω(err).ToNot(HaveOccurred())
 				Ω(r.origin).To(MatchRegexp("../test/vpc"))
@@ -58,7 +58,7 @@ var _ = Describe("Runner", func() {
 		Context("when run returns an error", func() {
 			It("should return an error", func() {
 				c, err := config.LoadConfigInTree(cwd+"/../test", "dev")
-				err = Run(myErrRun, c, Log, true, nil)
+				err = Run("TEST", myErrRun, c, Log, true, nil)
 				Ω(err).To(HaveOccurred())
 			})
 		})

--- a/cmd/runner_test.go
+++ b/cmd/runner_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Runner", func() {
 		Context("in reverse order", func() {
 			It("should make the correct calls", func() {
 				c, err := config.LoadConfigInTree(cwd+"/../test", "dev")
-                                err = Run("TEST", myRun, c, Log, true, nil)
+				err = Run("TEST", myRun, c, Log, true, nil)
 				Ω(r.callCount).To(Equal(3))
 				Ω(err).ToNot(HaveOccurred())
 				Ω(r.origin).To(MatchRegexp("../test/vpc"))

--- a/destroy/destroy.go
+++ b/destroy/destroy.go
@@ -25,14 +25,11 @@ func Run(c *config.Config, l log.Logger, args interface{}) error {
 	}
 
 	l.Log("Executing terraform destroy")
-	err, out := util.RunCmd(
+	return util.RunCmd(
 		"terraform",
 		"destroy",
 		"-force",
 		"-var-file", c.CombinedValsFilePath,
 		"-var-file", c.CombinedDerivedValsFilePath,
 	)
-
-	l.Log(out)
-	return err
 }

--- a/destroy/destroy.go
+++ b/destroy/destroy.go
@@ -3,7 +3,6 @@ package destroy
 import (
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
-	"github.com/craigmonson/colonize/prep"
 	"github.com/craigmonson/colonize/util"
 )
 
@@ -13,9 +12,6 @@ type RunArgs struct {
 
 func Run(c *config.Config, l log.Logger, args interface{}) error {
 	runArgs := args.(RunArgs)
-
-	// always run prep first
-	prep.Run(c, l, nil)
 
 	if runArgs.SkipRemote {
 		l.Log("Skipping remote setup")

--- a/generate/branch/branch.go
+++ b/generate/branch/branch.go
@@ -1,69 +1,75 @@
 package branch
 
 import (
-  "fmt"
-  "os"
-  "path"
-  "path/filepath"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 
-  "github.com/craigmonson/colonize/config"
-  "github.com/craigmonson/colonize/log"
-  "github.com/craigmonson/colonize/util"
-  "github.com/craigmonson/colonize/generate/leaf"
+	"github.com/fatih/color"
+
+	"github.com/craigmonson/colonize/config"
+	"github.com/craigmonson/colonize/generate/leaf"
+	"github.com/craigmonson/colonize/log"
+	"github.com/craigmonson/colonize/util"
 )
 
 type RunArgs struct {
-  Name  string
-  Leafs []string
+	Name  string
+	Leafs []string
 }
-
 
 func Run(c *config.Config, l log.Logger, args interface{}) error {
 
-  runArgs := args.(RunArgs)
-  l.Log("Creating Branch: " + runArgs.Name)
+	runArgs := args.(RunArgs)
+	l.LogPretty(util.PadRight(fmt.Sprintf("\nGENERATE [Branch | %s] ", runArgs.Name), "*", 79), color.Bold)
 
-  os.Chdir(c.TmplPath)
-  os.Mkdir(runArgs.Name, 0755)
+	os.Chdir(c.TmplPath)
 
-  parent_build_order,err := os.OpenFile(c.ConfigFile.Branch_Order_File, os.O_APPEND|os.O_WRONLY, 0664)
-  if err != nil {
-    l.Log(fmt.Sprintf("Failed to add branch '%s' to '%s'", runArgs.Name, "build_order.txt"))
-    os.Exit(-1)
-  }
-  parent_build_order.WriteString(runArgs.Name + "\n")
-  parent_build_order.Close()
+	parent_build_order, err := os.OpenFile(c.ConfigFile.Branch_Order_File, os.O_APPEND|os.O_WRONLY, 0664)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Failed to add branch '%s' to '%s'", runArgs.Name, c.ConfigFile.Branch_Order_File))
+		os.Exit(-1)
+	}
+	defer parent_build_order.Close()
 
+	l.Log("Creating branch directory...")
+	os.Mkdir(runArgs.Name, 0755)
 
-  os.Chdir(runArgs.Name)
-  os.Mkdir(c.ConfigFile.Environments_Dir, 0755)
+	l.Log("Creating branch environment directory...")
+	os.Chdir(runArgs.Name)
+	os.Mkdir(c.ConfigFile.Environments_Dir, 0755)
 
-  matches,_ := filepath.Glob(path.Join(c.RootPath, c.ConfigFile.Environments_Dir, "*.tfvars"))
-  for _,match := range matches {
-    util.Touch(c.ConfigFile.Environments_Dir,path.Base(match))
-  }
+	l.Log("Creating environment variables files...")
+	matches, _ := filepath.Glob(path.Join(c.RootPath, c.ConfigFile.Environments_Dir, "*.tfvars"))
+	for _, match := range matches {
+		util.Touch(c.ConfigFile.Environments_Dir, path.Base(match))
+	}
 
-  build_order,err := os.Create(c.ConfigFile.Branch_Order_File)
-  if err != nil {
-    return err
-  }
-  defer build_order.Close()
+	l.Log("Creating branch build order file...")
+	build_order, err := os.Create(c.ConfigFile.Branch_Order_File)
+	if err != nil {
+		return err
+	}
+	defer build_order.Close()
 
+	l.Log("Updating parent build order file...")
+	parent_build_order.WriteString(runArgs.Name + "\n")
 
-  if len(runArgs.Leafs) > 0 {
-    for _,leafName := range runArgs.Leafs {
-      if leafName != "" {
-        err = leaf.Run(c, l, leaf.RunArgs{
-          Name: leafName,
-          BuildOrder: build_order,
-        })
-        if err != nil {
-          return err
-        }
-      }
-    }
-  }
+	if len(runArgs.Leafs) > 0 {
+		for _, leafName := range runArgs.Leafs {
+			if leafName != "" {
+				err = leaf.Run(c, l, leaf.RunArgs{
+					Name:       leafName,
+					BuildOrder: build_order,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
 
-  return nil
+	return nil
 }
-

--- a/generate/leaf/leaf.go
+++ b/generate/leaf/leaf.go
@@ -1,25 +1,36 @@
 package leaf
 
 import (
-  "os"
+	"fmt"
+	"os"
 
-  "github.com/craigmonson/colonize/config"
-  "github.com/craigmonson/colonize/log"
-  "github.com/craigmonson/colonize/util"
+	"github.com/fatih/color"
+
+	"github.com/craigmonson/colonize/config"
+	"github.com/craigmonson/colonize/log"
+	"github.com/craigmonson/colonize/util"
 )
 
 type RunArgs struct {
-  Name string
-  BuildOrder *os.File
+	Name       string
+	BuildOrder *os.File
 }
 
 func Run(c *config.Config, l log.Logger, args interface{}) error {
-  runArgs := args.(RunArgs)
-  l.Log("Creating Leaf: " + runArgs.Name)
+	runArgs := args.(RunArgs)
 
-  os.Mkdir(runArgs.Name, 0755)
-  util.Touch(runArgs.Name,"main.tf")
-  runArgs.BuildOrder.WriteString(runArgs.Name + "\n")
+	cwd, _ := os.Getwd()
+	branch := util.GetBasename(cwd)
+	l.LogPretty(util.PadRight(fmt.Sprintf("\nGENERATE [Leaf | %s/%s] ", branch, runArgs.Name), "*", 79), color.Bold)
 
-  return nil
+	l.Log("Creating leaf directory...")
+	os.Mkdir(runArgs.Name, 0755)
+
+	l.Log("Creating main leaf terraform template...")
+	util.Touch(runArgs.Name, "main.tf")
+
+	l.Log("Updating branch build order file...")
+	runArgs.BuildOrder.WriteString(runArgs.Name + "\n")
+
+	return nil
 }

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -1,110 +1,171 @@
 package initialize
 
 import (
-  "bufio"
-  "bytes"
-  "errors"
-  "os"
-  "fmt"
-  "reflect"
-  "strings"
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
 
-  "github.com/craigmonson/colonize/config"
-  "github.com/craigmonson/colonize/log"
-  "github.com/craigmonson/colonize/util"
+	"github.com/fatih/color"
+
+	"github.com/craigmonson/colonize/config"
+	"github.com/craigmonson/colonize/log"
+	"github.com/craigmonson/colonize/util"
 )
 
 type RunArgs struct {
-  AcceptDefaults bool
-  InitEnvironments string
+	AcceptDefaults   bool
+	InitEnvironments string
+	ConfigBuffer     bytes.Buffer
 }
 
 func Run(c *config.Config, l log.Logger, args interface{}) error {
-  var configBuffer bytes.Buffer
-  runArgs := args.(RunArgs)
+	runArgs := args.(RunArgs)
 
-  scan := bufio.NewScanner(os.Stdin)
-  defaults := reflect.ValueOf(&config.ConfigFileDefaults).Elem()
-  actuals := reflect.ValueOf(&c.ConfigFile).Elem()
-  typeof := defaults.Type()
+	err := initTask("Config File", configFileTask, c, l, &runArgs)
+	if err != nil {
+		return err
+	}
 
-  if !runArgs.AcceptDefaults {
-    l.Log("Starting interactive setup:")
-  }
+	err = initTask("Environments", environmentsTask, c, l, &runArgs)
+	if err != nil {
+		return err
+	}
 
-  // Iterate through each field in the config file struct
-  // asking for user inout or setting to a default
-  for i := 0; i< defaults.NumField(); i++ {
+	err = initTask("Summary", summaryTask, c, l, &runArgs)
+	if err != nil {
+		return err
+	}
 
-    fieldName := strings.ToLower(typeof.Field(i).Name)
-    defaultField := defaults.Field(i)
-    actualField := actuals.Field(i)
+	return initTask("Create Artifacts", createArtifactsTask, c, l, &runArgs)
+}
 
-    if runArgs.AcceptDefaults || strings.HasPrefix(fieldName,"autogenerate_"){
-      actualField.Set(reflect.Value(defaultField))
-    } else {
-      l.Print(fmt.Sprintf("Enter '%s' [%v]: ", fieldName, defaultField.Interface()))
-      scan.Scan()
-      val := scan.Text()
+func initTask(name string, f func(*config.Config, log.Logger, *RunArgs) error, c *config.Config, l log.Logger, args *RunArgs) error {
+	l.LogPretty(util.PadRight(fmt.Sprintf("\nINIT [%s] ", name), "*", 79), color.Bold)
+	err := f(c, l, args)
+	return err
+}
 
-      if val == "" {
-        actualField.Set(reflect.Value(defaultField))
-      } else {
-        actualField.SetString(val)
-      }
-    }
+func configFileTask(c *config.Config, l log.Logger, args *RunArgs) error {
+	if !args.AcceptDefaults {
+		l.Log("Starting interactive setup...\n")
+	} else {
+		l.LogPretty("Skipping interactive setup...", color.FgBlue)
+	}
 
-    configBuffer.WriteString(fmt.Sprintf("%-30s => %v\n",fieldName,actualField.Interface()))
-  }
+	scan := bufio.NewScanner(os.Stdin)
+	defaults := reflect.ValueOf(&config.ConfigFileDefaults).Elem()
+	actuals := reflect.ValueOf(&c.ConfigFile).Elem()
+	typeof := defaults.Type()
 
-  // print configuration details
-  l.Log(fmt.Sprintf("\nInitializing Colonize using the following config:\n%s\n",configBuffer.String()))
+	// Iterate through each field in the config file struct
+	// asking for user inout or setting to a default
+	for i := 0; i < defaults.NumField(); i++ {
 
-  if !runArgs.AcceptDefaults {
-    // Confirm initialization
-    accept := ""
-    for accept == "" {
-      l.Print("Please enter [y] to accept this configuration or [n] to cancel: ")
-      scan.Scan()
-      accept = scan.Text()
-    }
+		fieldName := strings.ToLower(typeof.Field(i).Name)
+		defaultField := defaults.Field(i)
+		actualField := actuals.Field(i)
 
-    if accept != "y" {
-      return errors.New("Colonize initialization cancelled by user")
-    }
+		if args.AcceptDefaults || strings.HasPrefix(fieldName, "autogenerate_") {
+			actualField.Set(reflect.Value(defaultField))
+		} else {
+			l.PrintPretty(fmt.Sprintf("Enter '%s' [%v]: ", fieldName, defaultField.Interface()), color.Bold)
+			scan.Scan()
+			val := scan.Text()
 
-    if runArgs.InitEnvironments == "" {
-      l.Print("\nProvide a comma-separated list of environment names to initialize []: ")
-      scan.Scan()
-      runArgs.InitEnvironments = scan.Text()
-    }
+			if val == "" {
+				actualField.Set(reflect.Value(defaultField))
+			} else {
+				actualField.SetString(val)
+			}
+		}
 
-  }
+		args.ConfigBuffer.WriteString(fmt.Sprintf("%-30s => %v\n", fieldName, actualField.Interface()))
+	}
 
-  err := c.ConfigFile.WriteToFile(".colonize.yaml")
-  if err != nil {
-    return errors.New("Failed to create .colonize.yaml file: " + err.Error())
-  } else {
-    l.Log("Created Configuration file")
-  }
+	return nil
+}
 
-  err = os.Mkdir(c.ConfigFile.Environments_Dir, 0755)
-  if err != nil {
-    os.Remove(".colonize.yaml")
-    return errors.New("Failed to create environments directory: " + err.Error())
-  } else {
-    l.Log("Created Environments directory")
-  }
+func environmentsTask(c *config.Config, l log.Logger, args *RunArgs) error {
 
-  util.Touch(c.ConfigFile.Branch_Order_File)
-  l.Log("Created Branch Order File")
+	scan := bufio.NewScanner(os.Stdin)
 
-  envs := strings.Split(runArgs.InitEnvironments,",")
-  for _,env := range envs {
-    fn := env + ".tfvars"
-    util.Touch(c.ConfigFile.Environments_Dir, fn)
-    l.Log(fmt.Sprintf("Created %s environment variable file", env))
-  }
+	if args.InitEnvironments != "" {
+		l.LogPretty("Skipping interactive environments setup...", color.FgBlue)
+		l.Log("Environments configured from command line: " + args.InitEnvironments)
+	} else {
 
-  return nil
+		if !args.AcceptDefaults {
+			l.LogPretty(util.PadRight("\nInitialize [Environments] ", "*", 79), color.Bold)
+			l.Log("Starting environment setup\n")
+			l.PrintPretty("Provide a comma-separated list of environment names to initialize []: ", color.Bold)
+			scan.Scan()
+			args.InitEnvironments = scan.Text()
+		}
+
+		if args.InitEnvironments == "" {
+			l.LogPretty("No environments will be setup...", color.FgBlue)
+		}
+	}
+
+	args.ConfigBuffer.WriteString(fmt.Sprintf("%-30s => %s\n", "Environments", args.InitEnvironments))
+
+	return nil
+}
+
+func summaryTask(c *config.Config, l log.Logger, args *RunArgs) error {
+
+	scan := bufio.NewScanner(os.Stdin)
+
+	// print configuration details
+	l.Log(fmt.Sprintf("\nInitializing Colonize using the following configuration:\n%s", args.ConfigBuffer.String()))
+
+	if !args.AcceptDefaults {
+		// Confirm initialization
+		accept := ""
+		for accept == "" {
+			l.PrintPretty("Enter 'yes' to accept this configuration: ", color.Bold)
+			scan.Scan()
+			accept = scan.Text()
+		}
+
+		if accept != "yes" {
+			return errors.New("Colonize initialization cancelled by user")
+		}
+	}
+
+	return nil
+}
+
+func createArtifactsTask(c *config.Config, l log.Logger, args *RunArgs) error {
+
+	l.Log("Creating configuration file...")
+	err := c.ConfigFile.WriteToFile(".colonize.yaml")
+	if err != nil {
+		return errors.New("Failed to create .colonize.yaml file: " + err.Error())
+	}
+
+	l.Log("Creating environments directory...")
+	err = os.Mkdir(c.ConfigFile.Environments_Dir, 0755)
+	if err != nil {
+		os.Remove(".colonize.yaml")
+		return errors.New("Failed to create environments directory: " + err.Error())
+	}
+
+	l.Log("Creating branch order file...")
+	util.Touch(c.ConfigFile.Branch_Order_File)
+
+	if len(args.InitEnvironments) > 0 {
+		envs := strings.Split(args.InitEnvironments, ",")
+		for _, env := range envs {
+			fn := env + ".tfvars"
+			l.Log(fmt.Sprintf("Creating %s environment variable file...", env))
+			util.Touch(c.ConfigFile.Environments_Dir, fn)
+		}
+	}
+
+	return nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -2,11 +2,14 @@ package log
 
 import (
 	"fmt"
+
+	"github.com/fatih/color"
 )
 
 type Logger interface {
 	Log(string)
-        Print(string)
+	Print(string)
+	LogPretty(string, ...color.Attribute)
 }
 
 type Log struct {
@@ -19,4 +22,10 @@ func (l Log) Log(s string) {
 
 func (l Log) Print(s string) {
 	fmt.Print(s)
+}
+
+func (l Log) LogPretty(s string, p ...color.Attribute) {
+	color.Set(p...)
+	l.Log(s)
+	color.Unset()
 }

--- a/log/log.go
+++ b/log/log.go
@@ -29,3 +29,9 @@ func (l Log) LogPretty(s string, p ...color.Attribute) {
 	l.Log(s)
 	color.Unset()
 }
+
+func (l Log) PrintPretty(s string, p ...color.Attribute) {
+	color.Set(p...)
+	l.Print(s)
+	color.Unset()
+}

--- a/log/log.go
+++ b/log/log.go
@@ -10,6 +10,7 @@ type Logger interface {
 	Log(string)
 	Print(string)
 	LogPretty(string, ...color.Attribute)
+	PrintPretty(string, ...color.Attribute)
 }
 
 type Log struct {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -37,4 +37,28 @@ var _ = Describe("Log", func() {
 			Ω(out).To(Equal("something\n"))
 		})
 	})
+
+	Describe("Print", func() {
+		It("should log something", func() {
+			log.Print("something")
+			out := getStdoutStr()
+			Ω(out).To(Equal("something"))
+		})
+	})
+
+	Describe("LogPretty", func() {
+		It("should log something", func() {
+			log.LogPretty("something")
+			out := getStdoutStr()
+			Ω(out).To(Equal("something\n"))
+		})
+	})
+
+	Describe("PrintPretty", func() {
+		It("should log something", func() {
+			log.PrintPretty("something")
+			out := getStdoutStr()
+			Ω(out).To(Equal("something"))
+		})
+	})
 })

--- a/log_mock/mock.go
+++ b/log_mock/mock.go
@@ -2,6 +2,7 @@ package log_mock
 
 import (
 	"github.com/craigmonson/colonize/log"
+	"github.com/fatih/color"
 )
 
 type MockLog struct {
@@ -16,4 +17,12 @@ func (l *MockLog) Log(s string) {
 
 func (l *MockLog) Print(s string) {
 	l.Output = l.Output + s
+}
+
+func (l *MockLog) LogPretty(s string, p ...color.Attribute) {
+	l.Log(s)
+}
+
+func (l *MockLog) PrintPretty(s string, p ...color.Attribute) {
+	l.Print(s)
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -32,13 +32,12 @@ func Run(c *config.Config, l log.Logger, args interface{}) error {
 	l.Log(c.CombinedValsFilePath)
 	d, _ := os.Getwd()
 	l.Log(d)
-	err, out := util.RunCmd(
+	err := util.RunCmd(
 		"terraform",
 		"plan",
 		"-var-file", c.CombinedValsFilePath,
 		"-var-file", c.CombinedDerivedValsFilePath,
 		"-out", "terraform.tfplan",
 	)
-	l.Log(out)
 	return err
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/craigmonson/colonize/config"
 	"github.com/craigmonson/colonize/log"
-	"github.com/craigmonson/colonize/prep"
 	"github.com/craigmonson/colonize/util"
 )
 
@@ -15,9 +14,6 @@ type RunArgs struct {
 
 func Run(c *config.Config, l log.Logger, args interface{}) error {
 	runArgs := args.(RunArgs)
-
-	// always run prep first
-	prep.Run(c, l, nil)
 
 	if runArgs.SkipRemote {
 		l.Log("Skipping remote setup")

--- a/util/formatting.go
+++ b/util/formatting.go
@@ -1,0 +1,19 @@
+package util
+
+func PadRight(str string, pad string, length int) string {
+	for {
+		str += pad
+		if len(str) > length {
+			return str[0:length]
+		}
+	}
+}
+
+func PadLeft(str string, pad string, length int) string {
+	for {
+		str = pad + str
+		if len(str) > length-1 {
+			return str[0:length]
+		}
+	}
+}

--- a/util/formatting_test.go
+++ b/util/formatting_test.go
@@ -1,0 +1,41 @@
+package util_test
+
+import (
+	. "github.com/craigmonson/colonize/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("util/formatting", func() {
+
+	Describe("PadLeft", func() {
+		initial := "abc"
+		actual := PadLeft(initial, "X", 6)
+		expected := "XXXabc"
+
+		It("should a string of correct length", func() {
+			Ω(len(actual)).To(Equal(6))
+		})
+
+		It("should produce the expected result", func() {
+			Ω(actual).To(Equal(expected))
+		})
+
+	})
+
+	Describe("PadRight", func() {
+		initial := "abc"
+		actual := PadRight(initial, "X", 6)
+		expected := "abcXXX"
+
+		It("should a string of correct length", func() {
+			Ω(len(actual)).To(Equal(6))
+		})
+
+		It("should produce the expected result", func() {
+			Ω(actual).To(Equal(expected))
+		})
+
+	})
+})

--- a/util/shellout.go
+++ b/util/shellout.go
@@ -1,11 +1,12 @@
 package util
 
 import (
+	"os"
 	"os/exec"
 )
 
 type Cmder interface {
-	CombinedOutput() ([]byte, error)
+	Run() error
 }
 
 type Cmd struct {
@@ -13,12 +14,13 @@ type Cmd struct {
 }
 
 var NewCmd = func(cmd string, arg ...string) Cmder {
-	return exec.Command(cmd, arg...)
+	newCmd := exec.Command(cmd, arg...)
+	newCmd.Stdout = os.Stdout
+	newCmd.Stderr = os.Stderr
+	return newCmd
 }
 
-func RunCmd(cmd string, arg ...string) (error, string) {
+func RunCmd(cmd string, arg ...string) error {
 	newCmd := NewCmd(cmd, arg...)
-	output, err := newCmd.CombinedOutput()
-
-	return err, string(output)
+	return newCmd.Run()
 }

--- a/util/shellout_test.go
+++ b/util/shellout_test.go
@@ -15,9 +15,9 @@ type mockCmd struct {
 	callCount int
 }
 
-func (c *mockCmd) CombinedOutput() ([]byte, error) {
+func (c *mockCmd) Run() error {
 	c.callCount++
-	return []byte("test"), nil
+	return nil
 }
 
 // NOTE: this is actually testing the 'test' directory in the root of the
@@ -48,7 +48,6 @@ var _ = Describe("util/shellout", func() {
 	Describe("RunCmd", func() {
 		var origFunc func(string, ...string) Cmder
 		var err error
-		var output string
 		var mocked *mockCmd
 
 		BeforeEach(func() {
@@ -59,7 +58,7 @@ var _ = Describe("util/shellout", func() {
 				return mocked
 			}
 
-			err, output = RunCmd("ls", "-l")
+			err = RunCmd("ls", "-l")
 
 		})
 		AfterEach(func() {
@@ -72,10 +71,6 @@ var _ = Describe("util/shellout", func() {
 
 		It("should have called Run", func() {
 			Ω(mocked.callCount).To(Equal(1))
-		})
-
-		It("should have an output", func() {
-			Ω(output).ShouldNot(BeEmpty())
 		})
 	})
 })

--- a/util_mock/mock.go
+++ b/util_mock/mock.go
@@ -13,9 +13,9 @@ type MockCmd struct {
 	Cmd       string
 }
 
-func (c *MockCmd) CombinedOutput() ([]byte, error) {
+func (c *MockCmd) Run() error {
 	c.CallCount++
-	return []byte("test"),nil
+	return nil
 }
 
 var MCmd = &MockCmd{}


### PR DESCRIPTION
# depends on #45 so, merge after that one

fixes #34 

This branch makes the output format cleaner and uniform across all commands. It cleanly delineates which colonize command is running (even in the case of the implicit commands, such as `prep`) and what it is running on (ex. the leaf name). It also adds color/text style capabilities to the logger.

Example of a `generate` command run on a branch:
```
$ colonize generate branch app --leafs security_groups,database,instances

COLONIZE *********************************************************************

GENERATE [Branch | app] ******************************************************
Creating branch directory...
Creating branch environment directory...
Creating environment variables files...
Creating branch build order file...
Updating parent build order file...

GENERATE [Leaf | app/security_groups] ****************************************
Creating leaf directory...
Creating main leaf terraform template...
Updating branch build order file...

GENERATE [Leaf | app/database] ***********************************************
Creating leaf directory...
Creating main leaf terraform template...
Updating branch build order file...

GENERATE [Leaf | app/instances] **********************************************
Creating leaf directory...
Creating main leaf terraform template...
Updating branch build order file...

RECAP ************************************************************************
Completed successfully!
```

Note that the task headers are bolded and certain text, such as the `Completed successfully!` line can be colored. The `Completed successfully!` happens to be green