### PR TITLE
moved flags to appropriate commands instead of global and added versi…

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -6,6 +6,14 @@ import (
 	"github.com/craigmonson/colonize/apply"
 )
 
+type ApplyFlags struct {
+	Environment           string
+	SkipRemote            bool
+	RemoteStateAfterApply bool
+}
+
+var applyFlags = ApplyFlags{}
+
 var applyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Applies the Terraform plan to the target environment",
@@ -26,14 +34,14 @@ $ colonize apply --environment dev --skip-remote
 $ colonize apply --environment dev --skip-remote --remote-state-after-apply
         `,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig(true)
+		conf, err := GetConfig(applyFlags.Environment)
 		if err != nil {
 			CompleteFail(err.Error())
 		}
 
 		err = Run("APPLY", apply.Run, conf, Log, false, apply.RunArgs{
-			SkipRemote:            SkipRemote,
-			RemoteStateAfterApply: RemoteStateAfterApply,
+			SkipRemote:            applyFlags.SkipRemote,
+			RemoteStateAfterApply: applyFlags.RemoteStateAfterApply,
 		})
 		if err != nil {
 			CompleteFail("Apply failed to run: " + err.Error())
@@ -44,5 +52,14 @@ $ colonize apply --environment dev --skip-remote --remote-state-after-apply
 }
 
 func init() {
+	addEnvironmentFlag(applyCmd, &applyFlags.Environment)
+	addSkipRemoteFlag(applyCmd, &applyFlags.SkipRemote)
+	applyCmd.Flags().BoolVarP(
+		&applyFlags.RemoteStateAfterApply,
+		"remote-state-after-apply",
+		"s",
+		false,
+		"Run remote state after terraform apply (if it was skipped).",
+	)
 	RootCmd.AddCommand(applyCmd)
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -19,7 +19,7 @@ Example usage to clean a project:
 $ colonize clean
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig(false)
+		conf, err := GetConfigWithoutEnvironment()
 		if err != nil {
 			CompleteFail("Clean failed to run: " + err.Error())
 		}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -10,6 +10,13 @@ import (
 	"github.com/craigmonson/colonize/prep"
 )
 
+type DestroyFlags struct {
+	Environment string
+	SkipRemote  bool
+}
+
+var destroyFlags = DestroyFlags{}
+
 var yesToDestroy bool
 
 const WARNING_MSG string = `All managed infrastructure will be deleted.
@@ -32,7 +39,7 @@ $ colonize destroy -e dev
 $ colonize destroy -e dev -y
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig(true)
+		conf, err := GetConfig(destroyFlags.Environment)
 		if err != nil {
 			CompleteFail(err.Error())
 		}
@@ -53,7 +60,7 @@ $ colonize destroy -e dev -y
 		}
 
 		err = Run("DESTROY", destroy.Run, conf, Log, true, destroy.RunArgs{
-			SkipRemote: SkipRemote,
+			SkipRemote: destroyFlags.SkipRemote,
 		})
 
 		if err != nil {
@@ -65,6 +72,8 @@ $ colonize destroy -e dev -y
 }
 
 func init() {
+	addEnvironmentFlag(destroyCmd, &destroyFlags.Environment)
+	addSkipRemoteFlag(destroyCmd, &destroyFlags.SkipRemote)
 	destroyCmd.Flags().BoolVarP(
 		&yesToDestroy,
 		"accept",

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -60,7 +60,7 @@ colonize generate branch mybranch --leafs myleaf1,myleaf2
 			CompleteFail(err.Error())
 		}
 
-		conf, err := GetConfig(false)
+		conf, err := GetConfigWithoutEnvironment()
 		if err != nil {
 			CompleteFail(err.Error())
 		}
@@ -102,7 +102,7 @@ colonize generate leaf myleaf
 			CompleteFail(err.Error())
 		}
 
-		conf, err := GetConfig(false)
+		conf, err := GetConfigWithoutEnvironment()
 		if err != nil {
 			CompleteFail(err.Error())
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,7 +15,7 @@ var initCmd = &cobra.Command{
 	Long:  `This command is used to aid in the generation the .colonize.yaml configuration file and project directory structure.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		_, err := GetConfig(false)
+		_, err := GetConfigWithoutEnvironment()
 		if err == nil {
 			CompleteFail("Colonize project already initialized. Exiting.")
 		}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -7,6 +7,13 @@ import (
 	"github.com/craigmonson/colonize/prep"
 )
 
+type PlanFlags struct {
+	Environment string
+	SkipRemote  bool
+}
+
+var planFlags = PlanFlags{}
+
 // planCmd represents the plan command
 var planCmd = &cobra.Command{
 	Use:   "plan",
@@ -26,7 +33,7 @@ $ colonize plan -e dev --skip-remote
 $ colonize plan -e dev --skip-remote --remote-state-after-apply
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig(true)
+		conf, err := GetConfig(planFlags.Environment)
 		if err != nil {
 			CompleteFail(err.Error())
 		}
@@ -37,7 +44,7 @@ $ colonize plan -e dev --skip-remote --remote-state-after-apply
 		}
 
 		err = Run("PLAN", plan.Run, conf, Log, false, plan.RunArgs{
-			SkipRemote: SkipRemote,
+			SkipRemote: planFlags.SkipRemote,
 		})
 
 		if err != nil {
@@ -49,5 +56,7 @@ $ colonize plan -e dev --skip-remote --remote-state-after-apply
 }
 
 func init() {
+	addEnvironmentFlag(planCmd, &planFlags.Environment)
+	addSkipRemoteFlag(planCmd, &planFlags.SkipRemote)
 	RootCmd.AddCommand(planCmd)
 }

--- a/cmd/prep.go
+++ b/cmd/prep.go
@@ -6,6 +6,12 @@ import (
 	"github.com/craigmonson/colonize/prep"
 )
 
+type PrepFlags struct {
+	Environment string
+}
+
+var prepFlags = PrepFlags{}
+
 // prepCmd represents the prep command
 var prepCmd = &cobra.Command{
 	Use:   "prep",
@@ -28,7 +34,7 @@ terraform.
 $ colonize prep -e dev
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		conf, err := GetConfig(true)
+		conf, err := GetConfig(prepFlags.Environment)
 		if err != nil {
 			CompleteFail(err.Error())
 		}
@@ -42,5 +48,6 @@ $ colonize prep -e dev
 }
 
 func init() {
+	addEnvironmentFlag(prepCmd, &prepFlags.Environment)
 	RootCmd.AddCommand(prepCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of Colonize",
+	Long:  `Retrieve the version information for Colonize`,
+	Run: func(cmd *cobra.Command, args []string) {
+		Log.Log("Colonize v0.0.0")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
fixes #40 
fixes #49 


* Makes sure we are not using common short names for other things (i.e. -r and -a have history meaning recursive and all, but we were using for other purposes)
* Added version command
* Removed flags from Global and onto individual commands
